### PR TITLE
Incorportate lootQualityMod into extra mutations

### DIFF
--- a/Source/ACE.Server/Factories/LootGenerationFactory_Test.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Test.cs
@@ -149,6 +149,7 @@ namespace ACE.Server.Factories
             displayStats += ($" \n Treasure Items \n " +
                     $"---- \n " +
                     $"Armor={ls.ArmorCount} \n " +
+                    $"Shield={ls.ShieldCount} \n " +
                     $"MeleeWeapon={ls.MeleeWeaponCount} \n " +
                     $"Caster={ls.CasterCount} \n " +
                     $"MissileWeapon={ls.MissileWeaponCount} \n " +
@@ -178,6 +179,7 @@ namespace ACE.Server.Factories
 
             displayStats += $"\n Drop Rates \n ----\n " +
                                 $"Armor= {ls.ArmorCount / ls.TotalItems * 100}% \n " +
+                                $"Shield= {ls.ShieldCount / ls.TotalItems * 100}% \n " +
                                 $"MeleeWeapon= {ls.MeleeWeaponCount / ls.TotalItems * 100}% \n " +
                                 $"Caster= {ls.CasterCount / ls.TotalItems * 100}% \n " +
                                 $"MissileWeapon= {ls.MissileWeaponCount / ls.TotalItems * 100}% \n " +
@@ -226,10 +228,20 @@ namespace ACE.Server.Factories
                                 $"  Trinket = {ls.JewelryTrinketCount}\t Droprate = {ls.JewelryTrinketCount / ls.JewelryCount * 100}%\n");
             // Cantrip Counts
             displayStats += ($"\n Cantip Counts Stats \n ----\n" +
-                    //$"     Minor = {ls.MinorCantripCount}\t Droprate = {ls.MinorCantripCount / ls.TotalItems * 100}%\n" +
-                    //$"     Major = {ls.MajorCantripCount}\t Droprate = {ls.MajorCantripCount / ls.TotalItems * 100}%\n" +
+                    $"     Minor = {ls.MinorCantripCount}\t Droprate = {ls.MinorCantripCount / ls.TotalItems * 100}%\n" +
+                    $"     Major = {ls.MajorCantripCount}\t Droprate = {ls.MajorCantripCount / ls.TotalItems * 100}%\n" +
                     $"      Epic = {ls.EpicCantripCount}\t Droprate = {ls.EpicCantripCount / ls.TotalItems * 100}%\n" +
                     $" Legendary = {ls.LegendaryCantripCount}\t Droprate = {ls.LegendaryCantripCount / ls.TotalItems * 100}%\n");
+            // Mutation Counts
+            var weaponOrCasterCount = ls.MeleeWeaponCount + ls.MissileWeaponCount + ls.CasterCount;
+            displayStats += ($"\n Mutation Counts Stats \n ----\n" +
+                             $"    CrushingBlow = {ls.CrushingBlowCount}\t Droprate = {ls.CrushingBlowCount / weaponOrCasterCount * 100}%\n" +
+                             $"    BitingStrike = {ls.BitingStrikeCount}\t Droprate = {ls.BitingStrikeCount / weaponOrCasterCount * 100}%\n" +
+                             $"    Slayer = {ls.SlayerCount}\t \t Droprate = {ls.SlayerCount / weaponOrCasterCount * 100}%\n" +
+                             $"    Hollow = {ls.HollowCount}\t \t Droprate = {ls.HollowCount / weaponOrCasterCount * 100}%\n" +
+                             $"    ArmorCleaving = {ls.ArmorCleavingCount}\t Droprate = {ls.ArmorCleavingCount / weaponOrCasterCount * 100}%\n" +
+                             $"    ShieldCleaving = {ls.ShieldCleavingCount}\t Droprate = {ls.ShieldCleavingCount / weaponOrCasterCount * 100}%\n" +
+                             $"    AbsorbMagic = {ls.AbsorbMagicCount}\t Droprate = {ls.AbsorbMagicCount / ls.ShieldCount * 100}%\n");
 
             if (ls.HasManaCount == 0)
             {

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Weapon.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Weapon.cs
@@ -43,12 +43,18 @@ namespace ACE.Server.Factories
             return weaponSpeedMod;
         }
 
+        private static float ApplyQualityModToExtraMutationChance(float chance, float lootQualityMod)
+        {
+            return chance * (1 + lootQualityMod);
+        }
+
         private static bool RollCrushingBlow(TreasureDeath treasureDeath, WorldObject wo)
         {
             if (Common.ConfigManager.Config.Server.WorldRuleset != Common.Ruleset.CustomDM)
                 return false;
 
             var chance = ExtraMutationEffects.GetCrushingBlowChanceForTier(treasureDeath.Tier);
+            chance = ApplyQualityModToExtraMutationChance(chance, treasureDeath.LootQualityMod);
             if (chance > ThreadSafeRandom.Next(0.0f, 1.0f))
             {
                 float amount;
@@ -71,6 +77,7 @@ namespace ACE.Server.Factories
                 return false;
 
             var chance = ExtraMutationEffects.GetBitingStrikeChanceForTier(treasureDeath.Tier);
+            chance = ApplyQualityModToExtraMutationChance(chance, treasureDeath.LootQualityMod);
             if (chance > ThreadSafeRandom.Next(0.0f, 1.0f))
             {
                 float amount;
@@ -92,6 +99,7 @@ namespace ACE.Server.Factories
                 return false;
 
             var chance = SlayerTypeChance.GetSlayerChanceForTier(treasureDeath.Tier);
+            chance = ApplyQualityModToExtraMutationChance(chance, treasureDeath.LootQualityMod);
             if (chance > ThreadSafeRandom.Next(0.0f, 1.0f))
             {
                 wo.SlayerCreatureType = SlayerTypeChance.Roll(treasureDeath);
@@ -108,6 +116,7 @@ namespace ACE.Server.Factories
                 return false;
 
             var chance = ExtraMutationEffects.GetHollowChanceForTier(treasureDeath.Tier);
+            chance = ApplyQualityModToExtraMutationChance(chance, treasureDeath.LootQualityMod);
             if (chance > ThreadSafeRandom.Next(0.0f, 1.0f))
             {
                 wo.IgnoreMagicArmor = true;
@@ -126,6 +135,7 @@ namespace ACE.Server.Factories
                 return false;
 
             var chance = ExtraMutationEffects.GetArmorCleavingChanceForTier(treasureDeath.Tier);
+            chance = ApplyQualityModToExtraMutationChance(chance, treasureDeath.LootQualityMod);
             if (chance > ThreadSafeRandom.Next(0.0f, 1.0f))
             {
                 wo.IgnoreArmor = 0.75f;
@@ -141,6 +151,7 @@ namespace ACE.Server.Factories
                 return false;
 
             var chance = ExtraMutationEffects.GetShieldCleavingChanceForTier(treasureDeath.Tier);
+            chance = ApplyQualityModToExtraMutationChance(chance, treasureDeath.LootQualityMod);
             if (chance > ThreadSafeRandom.Next(0.0f, 1.0f))
             {
                 wo.IgnoreShield = 0.5f;
@@ -157,6 +168,7 @@ namespace ACE.Server.Factories
                 return false;
 
             var chance = ExtraMutationEffects.GetAbsorbMagicChanceForTier(treasureDeath.Tier);
+            chance = ApplyQualityModToExtraMutationChance(chance, treasureDeath.LootQualityMod);
             if (chance > ThreadSafeRandom.Next(0.0f, 1.0f))
             {
                 wo.AbsorbMagicDamage = 0.25f;

--- a/Source/ACE.Server/Factories/LootStats.cs
+++ b/Source/ACE.Server/Factories/LootStats.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 
 using ACE.Entity.Enum;
+using ACE.Entity.Enum.Properties;
 using ACE.Server.WorldObjects;
 
 namespace ACE.Server.Factories
@@ -10,6 +11,7 @@ namespace ACE.Server.Factories
     {
         // Counters
         public float ArmorCount { get; set; }
+        public float ShieldCount { get; set; }
         public float MeleeWeaponCount { get; set; }
         public float CasterCount { get; set; }
         public float MissileWeaponCount { get; set; }
@@ -19,7 +21,7 @@ namespace ACE.Server.Factories
         public float JewelryRingCount { get; set; }
         public float JewelryTrinketCount { get; set; }
         public float GemCount { get; set; }
-        public float AetheriaCount { get; set; }        
+        public float AetheriaCount { get; set; }
         public float ClothingCount { get; set; }
         public float CloakCount { get; set; }
         public float OtherCount { get; set; }
@@ -43,6 +45,13 @@ namespace ACE.Server.Factories
         public float MajorCantripCount { get; set; }
         public float EpicCantripCount { get; set; }
         public float LegendaryCantripCount { get; set; }
+        public float CrushingBlowCount { get; set;  }
+        public float BitingStrikeCount { get; set;  }
+        public float SlayerCount { get; set;  }
+        public float HollowCount { get; set;  }
+        public float ArmorCleavingCount { get; set;  }
+        public float ShieldCleavingCount { get; set;  }
+        public float AbsorbMagicCount { get; set;  }
 
 
         // Tables
@@ -66,7 +75,7 @@ namespace ACE.Server.Factories
         public int MaxAL { get; set; }
         public string MinALItem { get; set; }
         public string MaxALItem { get; set; }
-        
+
 
         // Pet Stats
         public int PetsTotalRatings { get; set; }
@@ -117,7 +126,7 @@ namespace ACE.Server.Factories
 
         public void AddItem(WorldObject wo, bool logStats)
         {
-            // Weapon Properties 
+            // Weapon Properties
             double missileDefMod = 0.00f;
             double magicDefMod = 0.00f;
             double wield = 0.00f;
@@ -187,7 +196,11 @@ namespace ACE.Server.Factories
                         }
                         break;
                     case ItemType.Armor:
-                        ArmorCount++;
+                        if (testItem.IsShield)
+                            ShieldCount++;
+                        else
+                            ArmorCount++;
+
                         string equipmentSet = "None    ";
                         cantrip = false;
                         // float cantripSpells = 0;
@@ -259,7 +272,7 @@ namespace ACE.Server.Factories
                                 jewelrySlot = "Trink";
                                 break;
                             default:
-                                // Console.WriteLine(testItem.Name);                            
+                                // Console.WriteLine(testItem.Name);
                                 break;
                         }
                         if (logStats)
@@ -631,6 +644,21 @@ namespace ACE.Server.Factories
                 {
                     LegendaryCantripCount++;
                 }
+
+                if (testItem.GetProperty(PropertyFloat.CriticalMultiplier) > 0)
+                    CrushingBlowCount++;
+                if (testItem.CriticalFrequency > 0)
+                    BitingStrikeCount++;
+                if (testItem.SlayerDamageBonus > 0)
+                    SlayerCount++;
+                if (testItem.IgnoreArmor > 0)
+                    ArmorCleavingCount++;
+                if (testItem.IgnoreShield > 0)
+                    ShieldCleavingCount++;
+                if (testItem.IgnoreMagicArmor == true)
+                    HollowCount++;
+                if (testItem.AbsorbMagicDamage > 0)
+                    AbsorbMagicCount++;
             }
         }
     }


### PR DESCRIPTION
I updated the testlootgencorpse script to track extra mutations, so that I could be confident in these changes. As implemented, it raises the chance from ~1% (0.5% slayers) to ~1.25% (0.625% slayers). I pulled the calculation into a shared function though, so you can tweak it as needed.

Test Results:
```
testlootgencorpse 150 1000000
Tier 4 treasure, 0 lootQualityMod

Armor         181376
Shield        16871
MeleeWeapon   163539
Caster        24777
MissileWeapon 36118

Mutation Counts Stats
----
CrushingBlow   Droprate = 1.0435139%
BitingStrike   Droprate = 1.030147%
Slayer         Droprate = 0.5297771%
Hollow         Droprate = 0.98469925%
ArmorCleaving  Droprate = 0.9343504%
ShieldCleaving Droprate = 0.9575198%
AbsorbMagic    Droprate = 0.966155%
```

```
testlootgencorpse 19 200000
Tier 4 treasure, 0.25 lootQualityMod

Armor         173740
Shield        16289
MeleeWeapon   177809
Caster        26821
MissileWeapon 38848

Mutation Counts Stats
----
CrushingBlow   Droprate = 1.3463229%
BitingStrike   Droprate = 1.3368764%
Slayer         Droprate = 0.692465%
Hollow         Droprate = 1.1931263%
ArmorCleaving  Droprate = 1.1730013%
ShieldCleaving Droprate = 1.2066798%
AbsorbMagic    Droprate = 1.203266%
```
