### PR TITLE
Update SpellTransferScroll.cs

### DIFF
--- a/Source/ACE.Server/WorldObjects/SpellTransferScroll.cs
+++ b/Source/ACE.Server/WorldObjects/SpellTransferScroll.cs
@@ -75,7 +75,7 @@ namespace ACE.Server.WorldObjects
                 return;
             }
 
-            if (!RecipeManager.VerifyUse(player, source, target, true) || target.Workmanship == null)
+            if (!RecipeManager.VerifyUse(player, source, target, true) || target.Workmanship == null || target.Retained == true)
             {
                 player.SendUseDoneEvent(WeenieError.YouDoNotPassCraftingRequirements);
                 return;


### PR DESCRIPTION
add retained check, so players don't eat retained items with spell extraction scrolls. some additional logic might need added to allow transfer scrolls to be used on retained items. as I see players not wanting to eat their retained items trying to extract, but may want to try to better their retained items by adding spells to them. not sure where that added logic would go.