### PR TITLE
Update SpellProjectile.cs

### DIFF
--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -585,8 +585,8 @@ namespace ACE.Server.WorldObjects
                 {
                     if (sourcePlayer == null)
                         baseDamage /= 2; // Monsters do half projectile spell damage.
-                    else if(isPVP && Common.ConfigManager.Config.Server.WorldRuleset == Common.Ruleset.CustomDM)
-                        baseDamage = (int)(baseDamage * 0.75f);
+                    //else if(isPVP && Common.ConfigManager.Config.Server.WorldRuleset == Common.Ruleset.CustomDM)
+                        //baseDamage = (int)(baseDamage * 0.75f);
                 }
 
                 weaponResistanceMod = GetWeaponResistanceModifier(weapon, sourceCreature, attackSkill, Spell.DamageType);


### PR DESCRIPTION
remove the 25% PvP war magic nerf, with the fact everyone runs aegis. its compounds to a 50% war damage nerf. our highest level mages are hitting for 60s with level 7 vulns and wars