### PR TITLE
Attempt to fix corner world death bug

### DIFF
--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionAutonomousPosition.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionAutonomousPosition.cs
@@ -17,6 +17,12 @@ namespace ACE.Server.Network.GameAction.Actions
 
             var position = new Position(message.Payload);
 
+            if (position.PositionX == 0 && position.PositionY == 0 && position.Cell == 0)
+            {
+                // fix invalid null location sent by client
+                return;
+            }
+
             var instanceTimestamp = message.Payload.ReadUInt16();
             var serverControlTimestamp = message.Payload.ReadUInt16();
             var teleportTimestamp = message.Payload.ReadUInt16();

--- a/Source/ACE.Server/WorldObjects/Player_Location.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Location.cs
@@ -826,6 +826,7 @@ namespace ACE.Server.WorldObjects
             // https://asheron.fandom.com/wiki/Special:Search?query=Lifestone+on+Relog%3A+Yes+
             // https://docs.google.com/spreadsheets/d/122xOw3IKCezaTDjC_hggWSVzYJ_9M_zUUtGEXkwNXfs/edit#gid=846612575
 
+            0x0000,     // Null Landblock
             0x0002,     // Viamontian Garrison
             0x0007,     // Town Network
             0x0056,     // Augmentation Realm Main Level


### PR DESCRIPTION
"I logged back in and fell to my death"

(From Bryan):
Was able to reproduce the void glitch three times.
1. Enable Relogic
2. Leave an apartments zone (going into the open world, this happened when taking the Uziz port from the Uziz apartments)
3. If someone is at the drop and logs you out, when you log back in you'll be in the void"